### PR TITLE
Renamed go package as `zdns/dns` instead of `miekg/dns`

### DIFF
--- a/Makefile.fuzz
+++ b/Makefile.fuzz
@@ -13,11 +13,11 @@ all: build
 
 .PHONY: build
 build:
-	go-fuzz-build -tags fuzz github.com/miekg/dns
+	go-fuzz-build -tags fuzz github.com/zdns/dns
 
 .PHONY: build-newrr
 build-newrr:
-	go-fuzz-build -func FuzzNewRR -tags fuzz github.com/miekg/dns
+	go-fuzz-build -func FuzzNewRR -tags fuzz github.com/zdns/dns
 
 .PHONY: fuzz
 fuzz:

--- a/Makefile.release
+++ b/Makefile.release
@@ -18,7 +18,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/miekg/dns"
+	"github.com/zdns/dns"
 )
 
 func main() {

--- a/dnsutil/util.go
+++ b/dnsutil/util.go
@@ -8,7 +8,7 @@ package dnsutil
 import (
 	"strings"
 
-	"github.com/miekg/dns"
+	"github.com/zdns/dns"
 )
 
 // AddOrigin adds origin to s if s is not already a FQDN.

--- a/duplicate_generate.go
+++ b/duplicate_generate.go
@@ -56,7 +56,7 @@ func loadModule(name string) (*types.Package, error) {
 
 func main() {
 	// Import and type-check the package
-	pkg, err := loadModule("github.com/miekg/dns")
+	pkg, err := loadModule("github.com/zdns/dns")
 	fatalIfErr(err)
 	scope := pkg.Scope()
 

--- a/example_test.go
+++ b/example_test.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/miekg/dns"
+	"github.com/zdns/dns"
 )
 
 // Retrieve the MX records for miek.nl.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/miekg/dns
+module github.com/zdns/dns
 
 go 1.19
 

--- a/msg_generate.go
+++ b/msg_generate.go
@@ -61,7 +61,7 @@ func loadModule(name string) (*types.Package, error) {
 
 func main() {
 	// Import and type-check the package
-	pkg, err := loadModule("github.com/miekg/dns")
+	pkg, err := loadModule("github.com/zdns/dns")
 	fatalIfErr(err)
 	scope := pkg.Scope()
 

--- a/privaterr_test.go
+++ b/privaterr_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/miekg/dns"
+	"github.com/zdns/dns"
 )
 
 const TypeISBN uint16 = 0xFF00

--- a/types_generate.go
+++ b/types_generate.go
@@ -98,7 +98,7 @@ func loadModule(name string) (*types.Package, error) {
 
 func main() {
 	// Import and type-check the package
-	pkg, err := loadModule("github.com/miekg/dns")
+	pkg, err := loadModule("github.com/zdns/dns")
 	fatalIfErr(err)
 	scope := pkg.Scope()
 


### PR DESCRIPTION
This should let us use `go get -u` from `zmap/zdns` without running into:
```
$ go mod tidy
go: github.com/zmap/dns@v1.1.59-zdns-0: parsing go.mod:
        module declares its path as: github.com/miekg/dns
                but was required as: github.com/zmap/dns
```