### PR TITLE
Fix module naming issue zdns -> zmap

### DIFF
--- a/Makefile.fuzz
+++ b/Makefile.fuzz
@@ -13,11 +13,11 @@ all: build
 
 .PHONY: build
 build:
-	go-fuzz-build -tags fuzz github.com/zdns/dns
+	go-fuzz-build -tags fuzz github.com/zmap/dns
 
 .PHONY: build-newrr
 build-newrr:
-	go-fuzz-build -func FuzzNewRR -tags fuzz github.com/zdns/dns
+	go-fuzz-build -func FuzzNewRR -tags fuzz github.com/zmap/dns
 
 .PHONY: fuzz
 fuzz:

--- a/Makefile.release
+++ b/Makefile.release
@@ -18,7 +18,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/zdns/dns"
+	"github.com/zmap/dns"
 )
 
 func main() {

--- a/dnsutil/util.go
+++ b/dnsutil/util.go
@@ -8,7 +8,7 @@ package dnsutil
 import (
 	"strings"
 
-	"github.com/zdns/dns"
+	"github.com/zmap/dns"
 )
 
 // AddOrigin adds origin to s if s is not already a FQDN.

--- a/duplicate_generate.go
+++ b/duplicate_generate.go
@@ -56,7 +56,7 @@ func loadModule(name string) (*types.Package, error) {
 
 func main() {
 	// Import and type-check the package
-	pkg, err := loadModule("github.com/zdns/dns")
+	pkg, err := loadModule("github.com/zmap/dns")
 	fatalIfErr(err)
 	scope := pkg.Scope()
 

--- a/example_test.go
+++ b/example_test.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/zdns/dns"
+	"github.com/zmap/dns"
 )
 
 // Retrieve the MX records for miek.nl.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/zdns/dns
+module github.com/zmap/dns
 
 go 1.19
 

--- a/msg_generate.go
+++ b/msg_generate.go
@@ -61,7 +61,7 @@ func loadModule(name string) (*types.Package, error) {
 
 func main() {
 	// Import and type-check the package
-	pkg, err := loadModule("github.com/zdns/dns")
+	pkg, err := loadModule("github.com/zmap/dns")
 	fatalIfErr(err)
 	scope := pkg.Scope()
 

--- a/privaterr_test.go
+++ b/privaterr_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/zdns/dns"
+	"github.com/zmap/dns"
 )
 
 const TypeISBN uint16 = 0xFF00

--- a/types_generate.go
+++ b/types_generate.go
@@ -98,7 +98,7 @@ func loadModule(name string) (*types.Package, error) {
 
 func main() {
 	// Import and type-check the package
-	pkg, err := loadModule("github.com/zdns/dns")
+	pkg, err := loadModule("github.com/zmap/dns")
 	fatalIfErr(err)
 	scope := pkg.Scope()
 


### PR DESCRIPTION
Mistakenly named the module `gitHub.com/zdns/dns` instead of `GitHub.com/zmap/dns`

