### PR TITLE
Re-add the socket re-use + a exchange w/ Context

### DIFF
--- a/client.go
+++ b/client.go
@@ -174,6 +174,15 @@ func (c *Client) Exchange(m *Msg, address string) (r *Msg, rtt time.Duration, er
 	return c.ExchangeWithConn(m, co)
 }
 
+// BEGIN MONKEY PATCH
+func (c *Client) ExchangeWithConnTo(m *Msg, conn *Conn, addr net.Addr) (r *Msg, rtt time.Duration, err error) {
+	conn.UnboundUDP = true
+	conn.RemoteAddr = addr
+	return c.ExchangeWithConn(m, conn)
+}
+
+// END MONKEY PATCH
+
 // ExchangeWithConn has the same behavior as Exchange, just with a predetermined connection
 // that will be used instead of creating a new one.
 // Usage pattern with a *dns.Client:

--- a/client.go
+++ b/client.go
@@ -31,7 +31,11 @@ func isPacketConn(c net.Conn) bool {
 
 // A Conn represents a connection to a DNS server.
 type Conn struct {
-	net.Conn                         // a net.Conn holding the connection
+	net.Conn // a net.Conn holding the connection
+	// BEGIN FAST UDP MONKEY PATCH
+	UnboundUDP bool
+	RemoteAddr net.Addr
+	// END FAST UDP MONKEY PATCH
 	UDPSize        uint16            // minimum receive buffer for UDP messages
 	TsigSecret     map[string]string // secret(s) for Tsig map[<zonename>]<base64 secret>, zonename must be in canonical form (lowercase, fqdn, see RFC 4034 Section 6.2)
 	TsigProvider   TsigProvider      // An implementation of the TsigProvider interface. If defined it replaces TsigSecret and is used for all TSIG operations.

--- a/client.go
+++ b/client.go
@@ -368,6 +368,7 @@ func (co *Conn) Write(p []byte) (int, error) {
 		return 0, &Error{err: "message too large"}
 	}
 
+	// Begin Monkey Patch
 	isPacketAConnection := isPacketConn(co.Conn)
 
 	if isPacketAConnection && co.UnboundUDP {
@@ -378,8 +379,8 @@ func (co *Conn) Write(p []byte) (int, error) {
 		return pc.WriteTo(p, co.RemoteAddr)
 	} else if isPacketAConnection {
 		return co.Conn.Write(p)
-
 	}
+	// End Monkey Patch
 
 	msg := make([]byte, 2+len(p))
 	binary.BigEndian.PutUint16(msg, uint16(len(p)))

--- a/client.go
+++ b/client.go
@@ -175,6 +175,7 @@ func (c *Client) Exchange(m *Msg, address string) (r *Msg, rtt time.Duration, er
 }
 
 // BEGIN MONKEY PATCH
+
 func (c *Client) ExchangeWithConnTo(m *Msg, conn *Conn, addr net.Addr) (r *Msg, rtt time.Duration, err error) {
 	conn.UnboundUDP = true
 	conn.RemoteAddr = addr

--- a/client.go
+++ b/client.go
@@ -368,8 +368,17 @@ func (co *Conn) Write(p []byte) (int, error) {
 		return 0, &Error{err: "message too large"}
 	}
 
-	if isPacketConn(co.Conn) {
+	isPacketAConnection := isPacketConn(co.Conn)
+
+	if isPacketAConnection && co.UnboundUDP {
+		pc, ok := co.Conn.(net.PacketConn)
+		if !ok {
+			return 0, &Error{err: "not a packet connection"}
+		}
+		return pc.WriteTo(p, co.RemoteAddr)
+	} else if isPacketAConnection {
 		return co.Conn.Write(p)
+
 	}
 
 	msg := make([]byte, 2+len(p))

--- a/client.go
+++ b/client.go
@@ -181,6 +181,12 @@ func (c *Client) ExchangeWithConnTo(m *Msg, conn *Conn, addr net.Addr) (r *Msg, 
 	return c.ExchangeWithConn(m, conn)
 }
 
+func (c *Client) ExchangeWithConnToContext(ctx context.Context, m *Msg, conn *Conn, addr net.Addr) (r *Msg, rtt time.Duration, err error) {
+	conn.UnboundUDP = true
+	conn.RemoteAddr = addr
+	return c.ExchangeWithConnContext(ctx, m, conn)
+}
+
 // END MONKEY PATCH
 
 // ExchangeWithConn has the same behavior as Exchange, just with a predetermined connection


### PR DESCRIPTION
Somehow, the code changes added to `miekg/dns` didn't carry over when updating the fork. This re-adds the old code and adds a new `ExchangeWithConnToContext` so we can use contexts appropriately in `zdns`