### PR TITLE
Phillip/fix sync fork

### DIFF
--- a/.github/workflows/sync_fork.yml
+++ b/.github/workflows/sync_fork.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
+        with:
+            fetch-depth: 0  # Fetch all history so that we can compare with upstream
 
       - name: Check for new changes
         id: check_updates

--- a/.github/workflows/sync_fork.yml
+++ b/.github/workflows/sync_fork.yml
@@ -12,18 +12,12 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
 
-      - name: Set up Git and pull latest changes
-        run: |
-          git pull
-
-      - name: Add upstream remote and fetch
-        run: |
-          git remote add upstream https://github.com/miekg/dns.git
-          git fetch upstream
-
       - name: Check for new changes
         id: check_updates
         run: |
+          git pull
+          git remote add upstream https://github.com/miekg/dns.git
+          git fetch upstream
           UPDATES=$(git rev-list --count HEAD..upstream/master)
           if [ "$UPDATES" -gt 0 ]; then
             echo "There are $UPDATES new upstream changes available."

--- a/.github/workflows/sync_fork.yml
+++ b/.github/workflows/sync_fork.yml
@@ -19,7 +19,6 @@ jobs:
           git remote add upstream https://github.com/miekg/dns.git
           git fetch upstream
 
-
       - name: Check for new changes
         id: check_updates
         run: |

--- a/.github/workflows/sync_fork.yml
+++ b/.github/workflows/sync_fork.yml
@@ -46,6 +46,7 @@ jobs:
           branch: sync-upstream-$(date +%Y%m%d)
           delete-branch: true
           title: "Sync miekg/dns upstream changes"
-          body: "Automated PR to sync upstream changes from miekg/dns. Please review and merge if appropriate."
+          body: "Automated PR to sync upstream changes from miekg/dns. Please review and merge if appropriate.
+                  ALERT - If upstream tagged a new version, you'll need to tag manually after merging this PR."
           labels: "sync, automated"
           assignees: "phillip-stephens"

--- a/.github/workflows/sync_fork.yml
+++ b/.github/workflows/sync_fork.yml
@@ -10,16 +10,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
             fetch-depth: 0  # Fetch all history so that we can compare with upstream
+
+      - name: Add upstream remote and fetch
+        run: |
+          git remote add upstream https://github.com/miekg/dns.git
+          git fetch upstream
+
 
       - name: Check for new changes
         id: check_updates
         run: |
-          git pull
-          git remote add upstream https://github.com/miekg/dns.git
-          git fetch upstream
           UPDATES=$(git rev-list --count HEAD..upstream/master)
           if [ "$UPDATES" -gt 0 ]; then
             echo "There are $UPDATES new upstream changes available."

--- a/.github/workflows/sync_fork.yml
+++ b/.github/workflows/sync_fork.yml
@@ -14,8 +14,6 @@ jobs:
 
       - name: Set up Git and pull latest changes
         run: |
-          git config --global user.name 'GitHub Actions'
-          git config --global user.email '
           git pull
 
       - name: Add upstream remote and fetch

--- a/.github/workflows/sync_fork.yml
+++ b/.github/workflows/sync_fork.yml
@@ -12,6 +12,12 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
 
+      - name: Set up Git and pull latest changes
+        run: |
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email '
+          git pull
+
       - name: Add upstream remote and fetch
         run: |
           git remote add upstream https://github.com/miekg/dns.git


### PR DESCRIPTION
Didn't know the default behavior of the Github checkout action is not to fetch the full history of commits. This caused the check for how many new commits were on `upstream` to fail. 🫠 